### PR TITLE
feat: add docker support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,27 @@ To set up the PassGuard project on your local machine, follow these steps:
 2. **Install Project Dependencies**: PassGuard uses `pnpm` for managing dependencies. Run `pnpm i` to install all necessary dependencies.
 3. **Run the Project**: Start the PassGuard project in development mode or locally by running `pnpm tauri dev`.
 
+## Building for Desktop
+
+To generate desktop application binaries for PassGuard, the following steps use Docker to streamline the build process. Follow these instructions:
+
+1. Navigate to the `desktop` directory in your PassGuard project.
+
+2. Run the following command in your terminal:
+
+   ```bash
+   docker-compose -f docker-compose.build.yml up
+   ```
+
+   This command triggers the build process for the application binaries.
+
+3. Once the build is completed, check the `dist` directory within the `desktop` directory. You will find the following sub-directories:
+
+   - `appimage`: Contains the AppImage format for Linux distributions.
+   - `deb`: Holds the Debian package for Debian-based Linux distributions.
+   - `rpm`: Contains the RPM package for Red Hat-based Linux distributions.
+   - `nsis`: Holds the NSIS installer for Windows.
+
+Please note that PassGuard currently supports Windows and Linux platforms.
 
 ### Thank you for your contributions!

--- a/desktop/.dockerignore
+++ b/desktop/.dockerignore
@@ -4,3 +4,4 @@ node_modules
 .svelte-kit
 build
 build-tauri
+.xwin-cache

--- a/desktop/.dockerignore
+++ b/desktop/.dockerignore
@@ -1,0 +1,6 @@
+src-tauri/target
+src-tauri/gen/schemas
+node_modules
+.svelte-kit
+build
+build-tauri

--- a/desktop/.dockerignore
+++ b/desktop/.dockerignore
@@ -3,5 +3,5 @@ src-tauri/gen/schemas
 node_modules
 .svelte-kit
 build
-build-tauri
+dist
 .xwin-cache

--- a/desktop/.eslintignore
+++ b/desktop/.eslintignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+/build-tauri

--- a/desktop/.eslintignore
+++ b/desktop/.eslintignore
@@ -12,4 +12,4 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 
-/build-tauri
+dist

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -10,3 +10,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 pnpm-lock.yaml
 build-tauri
+.xwin-cache

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -9,3 +9,4 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 pnpm-lock.yaml
+build-tauri

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -9,5 +9,5 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 pnpm-lock.yaml
-build-tauri
+dist
 .xwin-cache

--- a/desktop/.prettierignore
+++ b/desktop/.prettierignore
@@ -2,3 +2,4 @@
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+.xwin-cache

--- a/desktop/Dockerfile.build
+++ b/desktop/Dockerfile.build
@@ -1,12 +1,9 @@
-# For Windows build stage
-FROM debian:bookworm
+# Define the base image for the Linux environment
+FROM debian:bookworm as linux-base
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    # Add your dependencies here
-    javascriptcoregtk-4.1 \
-    libsoup-3.0 \
-    webkit2gtk-4.1 \
+# Install dependencies required by tauri (https://beta.tauri.app/guides/prerequisites#linux)
+RUN apt update && apt install -y \
+    libwebkit2gtk-4.1-dev \
     build-essential \
     curl \
     wget \
@@ -14,37 +11,41 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libayatana-appindicator3-dev \
     librsvg2-dev \
-    # to buil executable (exe) for windows 
+    # Dependecies required for building windows executable (exe) 
     nsis \
     lld \
     llvm
 
+# Install Node.js version 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt install -y nodejs
+
+# Install pnpm globally (a fast package manager for Node.js projects)
+RUN npm install -g pnpm
+
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# Set PATH to include Cargo
+# Set PATH to include Cargo (Rust's package manager)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install the Windows Rust target
+# Install the Windows Rust target 
+# Refer to https://tauri.app/v1/guides/building/cross-platform/#experimental-build-windows-apps-on-linux-and-macos to learn more
 RUN rustup target add x86_64-pc-windows-msvc
 
-# To get the Windows SDKs required by the msvc target we will use the xwin project
-RUN cargo install xwin
-RUN xwin --accept-license splat --output /xwin
+# To get the Windows SDKs required by the MSVC target, we use the xwin project
+# Install the xwin tool (https://github.com/Jake-Shadle/xwin)
+RUN cargo install xwin \
+    && xwin --accept-license splat --output /xwin
 
-# Install Node.js version 20
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y nodejs
-
-# Set working directory
+# Set working directory inside the container
 WORKDIR /app
 
-# Copy application code
+# Copy the application code into the container
 COPY . .
 
-# Install dependencies
-RUN npm install -g pnpm
+# Install dependencies using pnpm
 RUN pnpm install
 
-# Build for Windows
-CMD pnpm exec tauri build && pnpm exec tauri build --target x86_64-pc-windows-msvc && cp -r /app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis /app/src-tauri/target/release/bundle
+# Build for linux and windows
+CMD pnpm exec tauri build && pnpm tauri build --target x86_64-pc-windows-msvc && cp -r /app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis /app/src-tauri/target/release/bundle

--- a/desktop/Dockerfile.build
+++ b/desktop/Dockerfile.build
@@ -1,0 +1,26 @@
+# LINK https://github.com/ivangabriele/docker-tauri
+# The base image has following things already installed: rust, node, yarn, tauri
+FROM ivangabriele/tauri:debian-bookworm-18
+
+# Just in case if anyone the pre-requisites are missing
+# LINK https://beta.tauri.app/guides/prerequisites#linux
+RUN apt install -y libwebkit2gtk-4.1-dev \
+  build-essential \
+  curl \
+  wget \
+  file \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+
+# setting CWD
+WORKDIR /app
+
+# copying context files
+COPY . .
+
+# installting dependencies
+RUN yarn install
+
+# running build command
+CMD yarn exec tauri build

--- a/desktop/Dockerfile.build
+++ b/desktop/Dockerfile.build
@@ -1,26 +1,50 @@
-# LINK https://github.com/ivangabriele/docker-tauri
-# The base image has following things already installed: rust, node, yarn, tauri
-FROM ivangabriele/tauri:debian-bookworm-18
+# For Windows build stage
+FROM debian:bookworm
 
-# Just in case if any of the pre-requisites are missing
-# LINK https://beta.tauri.app/guides/prerequisites#linux
-RUN apt install -y libwebkit2gtk-4.1-dev \
-  build-essential \
-  curl \
-  wget \
-  file \
-  libssl-dev \
-  libayatana-appindicator3-dev \
-  librsvg2-dev
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    # Add your dependencies here
+    javascriptcoregtk-4.1 \
+    libsoup-3.0 \
+    webkit2gtk-4.1 \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    # to buil executable (exe) for windows 
+    nsis \
+    lld \
+    llvm
 
-# setting CWD
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Set PATH to include Cargo
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install the Windows Rust target
+RUN rustup target add x86_64-pc-windows-msvc
+
+# To get the Windows SDKs required by the msvc target we will use the xwin project
+RUN cargo install xwin
+RUN xwin --accept-license splat --output /xwin
+
+# Install Node.js version 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y nodejs
+
+# Set working directory
 WORKDIR /app
 
-# copying context files
+# Copy application code
 COPY . .
 
-# installting dependencies
-RUN yarn install
+# Install dependencies
+RUN npm install -g pnpm
+RUN pnpm install
 
-# running build command
-CMD yarn exec tauri build
+# Build for Windows
+CMD pnpm exec tauri build && pnpm exec tauri build --target x86_64-pc-windows-msvc && cp -r /app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis /app/src-tauri/target/release/bundle

--- a/desktop/Dockerfile.build
+++ b/desktop/Dockerfile.build
@@ -2,7 +2,7 @@
 # The base image has following things already installed: rust, node, yarn, tauri
 FROM ivangabriele/tauri:debian-bookworm-18
 
-# Just in case if anyone the pre-requisites are missing
+# Just in case if any of the pre-requisites are missing
 # LINK https://beta.tauri.app/guides/prerequisites#linux
 RUN apt install -y libwebkit2gtk-4.1-dev \
   build-essential \

--- a/desktop/Dockerfile.build
+++ b/desktop/Dockerfile.build
@@ -1,5 +1,5 @@
 # Define the base image for the Linux environment
-FROM debian:bookworm as linux-base
+FROM debian:bookworm
 
 # Install dependencies required by tauri (https://beta.tauri.app/guides/prerequisites#linux)
 RUN apt update && apt install -y \
@@ -47,5 +47,9 @@ COPY . .
 # Install dependencies using pnpm
 RUN pnpm install
 
-# Build for linux and windows
-CMD pnpm exec tauri build && pnpm tauri build --target x86_64-pc-windows-msvc && cp -r /app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis /app/src-tauri/target/release/bundle
+# Build for linux
+CMD pnpm exec tauri build \
+    # build for windows
+    && pnpm tauri build --target x86_64-pc-windows-msvc \
+    # copy windows build files to mounted directory
+    && cp -r /app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis /app/src-tauri/target/release/bundle

--- a/desktop/docker-compose.build.yml
+++ b/desktop/docker-compose.build.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  build-desktop:
+    container_name: passguard-build-desktop
+    build:
+      context: .
+      dockerfile: Dockerfile.build
+    environment:
+      - NODE_ENV=production
+    volumes:
+      # Attaching bundle directory from container to host machine
+      - ./build-tauri:/app/src-tauri/target/release/bundle

--- a/desktop/docker-compose.build.yml
+++ b/desktop/docker-compose.build.yml
@@ -1,13 +1,10 @@
 version: '3.8'
 
 services:
-  build-desktop:
+  build:
     container_name: passguard-build-desktop
     build:
       context: .
       dockerfile: Dockerfile.build
-    environment:
-      - NODE_ENV=production
     volumes:
-      # Attaching bundle directory from container to host machine
       - ./build-tauri:/app/src-tauri/target/release/bundle

--- a/desktop/docker-compose.build.yml
+++ b/desktop/docker-compose.build.yml
@@ -1,10 +1,14 @@
 version: '3.8'
 
 services:
-  build:
-    container_name: passguard-build-desktop
+  desktop-builds:
     build:
+      # Specify the path to the Dockerfile
       context: .
+      # Specify the Dockerfile to use for building the image
       dockerfile: Dockerfile.build
+
+    # Mount a volume to store the built application artifacts
     volumes:
-      - ./build-tauri:/app/src-tauri/target/release/bundle
+      # Map the local 'dist' directory to the directory where the built artifacts will be stored in the container
+      - ./dist:/app/src-tauri/target/release/bundle

--- a/desktop/src-tauri/.cargo/config.toml
+++ b/desktop/src-tauri/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-pc-windows-msvc]
+linker = "lld"
+rustflags = [
+  "-Lnative=/xwin/crt/lib/x86_64",
+  "-Lnative=/xwin/sdk/lib/um/x86_64",
+  "-Lnative=/xwin/sdk/lib/ucrt/x86_64"
+]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
     ],
     "targets": "all"
   },
-  "identifier": "com.tauri.dev",
+  "identifier": "com.passguard.desktop",
   "productName": "PassGuard",
   "version": "0.1.0"
 }


### PR DESCRIPTION
# What was changed?

As of now, all builds were happening on host machine which is not ideal solution when building applications. Docker will provide isolated container where all the build process will take part and the final build will be mounted on host machine.

# Why docker?

Docker provides isolated environment for the building process, which is a good practice in-general. Not using isolated environment may lead to problems like files getting corrupted, bad cache handling, etc. **on host machine**. Docker will isolate all intermediate build files and only mount the final output into the host machine.

# How to build the application?

To build the application, make sure docker is installed on your system. For Debian based distro, run the following command to install docker:

```bash
sudo apt install -y docker.io docker-compose
```

next, we will need to run `docker-compose` command to spin a container that handles the build process:

```bash
sudo docker-compose --file docker-compose.build.yml up --remove-orphans --force-recreate --build
```

to make sure, everything gets build without any cache issues, i have used following flags:

- `--remove-orphans` will remove any dangling orphan containers
- `--force-recreate` will recreate containers even if their configuration and image haven't change
- `--build` will build images before starting containers