### PR TITLE
fix: sidebar items not clickable sometimes

### DIFF
--- a/desktop/src/components/layout/Sidebar.svelte
+++ b/desktop/src/components/layout/Sidebar.svelte
@@ -18,12 +18,12 @@
 	{#each navItems as { name, path, Icon } (path)}
 		<!-- TODO: Setup tooltips to show name -->
 
-		<a
-			href={path}
+		<button
+			on:mousedown={() => goto(path)}
 			class="nav-item bounce-effect {containsPath($page.route.id, path) ? 'active' : ''}"
 		>
 			<Icon weight={containsPath($page.route.id, path) ? 'fill' : 'regular'} />
-		</a>
+		</button>
 	{/each}
 
 	<!-- Flexible Spacer -->


### PR DESCRIPTION
## Problem
All sidebar items are essentially anchor tag (`<a>`) , so when user tries to click the item; due to slight drag of mouse, the event is not being registered as `click` event which leads user to click multiple times.

## Fix
To fix this issue, we can replace the anchor tag with button tag and listen for `mousedown` event which will be triggered even if the user tried to drag the item (unintentionally).